### PR TITLE
ci: enforce develop-only PRs into main

### DIFF
--- a/.github/workflows/enforce-develop-to-main.yml
+++ b/.github/workflows/enforce-develop-to-main.yml
@@ -1,0 +1,19 @@
+name: enforce-develop-to-main
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  enforce:
+    name: require develop as source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if head branch is not develop
+        run: |
+          echo "Head ref: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "Only PRs from 'develop' are allowed into 'main'. Current: '${{ github.head_ref }}'"
+            exit 1
+          fi


### PR DESCRIPTION
This adds a GitHub Actions gate that blocks any PR into main unless the head branch is develop.\n\nWhy\n- WARP.md requires all work to be based on develop and only allow PRs from develop into main.\n- Prevents accidental merges from feature branches or direct pushes.\n\nWhat\n- New workflow: .github/workflows/enforce-develop-to-main.yml\n- Runs on pull_request_target for base=main\n- Fails if the head branch is not 'develop'\n\nFollow-up\n- After this workflow runs at least once on a main-targeting PR, we will add its check as a required status check on the main branch protection settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a GitHub Actions workflow that blocks pull requests into main unless they originate from develop, improving release discipline and reducing accidental direct merges.
  * No user-facing changes; this update only affects the repository’s pull request process and does not impact runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->