### PR TITLE
ci(status): harden status board automation for 2025

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: SuperPassword Main Pipeline
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - develop
@@ -159,7 +160,15 @@ jobs:
   project-sync:
     name: Project Sync
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'issues' || github.event_name == 'issue_comment'
+    # Avoid infinite loops on self-updates and restrict to relevant events
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.actor != 'github-actions[bot]' && github.event.issue.number != 81) ||
+      (github.event_name == 'issue_comment' && github.actor != 'github-actions[bot]')
+    concurrency:
+      group: project-sync
+      cancel-in-progress: true
     env:
       PROJECTS_V2_OWNER: IgorGanapolsky
       PROJECTS_V2_NUMBER: 1
@@ -173,6 +182,18 @@ jobs:
             const repo = context.repo.repo;
             const projectOwner = process.env.PROJECTS_V2_OWNER || owner;
             const projectNumber = parseInt(process.env.PROJECTS_V2_NUMBER || '1', 10);
+
+            // Guard again inside the script to be extra safe
+            try {
+              if (context.eventName === 'issues') {
+                const num = context?.payload?.issue?.number;
+                const actor = context?.actor;
+                if (num === 81 || actor === 'github-actions[bot]') {
+                  core.info('Skipping self-triggered status issue update run.');
+                  return;
+                }
+              }
+            } catch {}
 
             // Helpers
             function median(nums) {


### PR DESCRIPTION
Summary\n- Add workflow_dispatch trigger for manual refresh\n- Add job-level loop guard to avoid self-trigger on status issue edits\n- Add concurrency (cancel-in-progress) to prevent overlapping runs\n\nWhy\n- Status board appeared idle because schedule runs only from default branch and the workflow was not yet on main; plus self-edits were causing noisy chains.\n- In 2025, Projects v2 API often requires a PAT with project access; we fall back to GITHUB_TOKEN, but if Projects access fails, we still update core metrics without blocking.\n\nFollow-up\n- Set a secret PROJECT_PAT (classic or fine-grained) with project read access for user/org projects, then the Project Board section will populate.\n- Repo Settings > Actions > General: set Workflow permissions to "Read and write permissions" and allow GitHub Actions to create and approve pull requests (optional).