### PR TITLE
ci(claude): automated PR review via API (develop flow)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "RadonAi": {
-      "url": "http://127.0.0.1:52813/mcp",
+      "url": "http://127.0.0.1:58644/mcp",
       "type": "http",
       "headers": {
-        "nonce": "2c6d5345-94ae-42ce-8634-4daed0b6fc4d"
+        "nonce": "dfad1002-4d90-460f-b619-76559338ad70"
       }
     }
   }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,144 @@
+name: Claude Automated Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  claude-review:
+    name: Claude Review (API)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect PR context and prepare prompt
+        id: prep
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed('No pull_request in event context.');
+              return;
+            }
+
+            // Fetch changed files with patches, but cap payload to ~40KB to control token usage
+            const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: pr.number, per_page: 100 });
+            let budget = 40000; // bytes
+            const snippets = [];
+            for (const f of files) {
+              const header = `FILE: ${f.filename} (+${f.additions}/-${f.deletions})`;
+              const patch = f.patch || '';
+              const take = Math.max(0, Math.min(budget - header.length - 100, patch.length));
+              const chunk = patch.slice(0, take);
+              budget -= (header.length + chunk.length + 100);
+              snippets.push(`${header}\n${chunk}`);
+              if (budget <= 0) break;
+            }
+
+            const prompt = [
+              `Repository: ${owner}/${repo}`,
+              `PR #${pr.number}: ${pr.title}`,
+              'Review the following diff snippets for correctness, security, test impact, and style.',
+              'Reply with:',
+              ' - A short overall assessment',
+              ' - Concrete, line-anchored suggestions in markdown bullets',
+              ' - Any security concerns and suggested remediations',
+              '',
+              'Diff snippets (truncated):',
+              '---',
+              ...snippets,
+            ].join('\n');
+
+            core.setOutput('prompt', prompt);
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('issue', pr.number.toString());
+
+      - name: Call Claude API and generate review
+        id: call
+        uses: actions/github-script@v7
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PROMPT: ${{ steps.prep.outputs.prompt }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const apiKey = process.env.ANTHROPIC_API_KEY;
+            if (!apiKey) {
+              core.warning('ANTHROPIC_API_KEY missing; skipping Claude review.');
+              core.setOutput('review', 'Claude API key not configured.');
+              core.setOutput('ok', 'false');
+              return;
+            }
+            const prompt = process.env.PROMPT || '';
+            if (!prompt) {
+              core.warning('No prompt available from prep step; skipping Claude review.');
+              core.setOutput('review', 'No diff context available.');
+              core.setOutput('ok', 'false');
+              return;
+            }
+            const body = {
+              model: 'claude-3-5-sonnet-20240620',
+              max_tokens: 1200,
+              temperature: 0.2,
+              messages: [{ role: 'user', content: prompt }]
+            };
+            const res = await fetch('https://api.anthropic.com/v1/messages', {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'x-api-key': apiKey,
+                'anthropic-version': '2023-06-01'
+              },
+              body: JSON.stringify(body)
+            });
+            if (!res.ok) {
+              const t = await res.text();
+              core.warning(`Claude API error: ${res.status} ${t.slice(0,300)}`);
+              core.setOutput('review', `Claude API error ${res.status}.`);
+              core.setOutput('ok', 'false');
+              return;
+            }
+            const data = await res.json();
+            const text = (data && data.content && data.content[0] && data.content[0].text) || 'No content';
+            core.setOutput('review', text);
+            core.setOutput('ok', 'true');
+
+      - name: Post review as PR comment
+        if: steps.call.outputs.ok == 'true'
+        uses: actions/github-script@v7
+        env:
+          ISSUE: ${{ steps.prep.outputs.issue }}
+          REVIEW: ${{ steps.call.outputs.review }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = parseInt(process.env.ISSUE, 10);
+            const body = `### 🤖 Claude Automated Review\n\n${process.env.REVIEW || 'No review content.'}`;
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+      - name: Set commit status (Claude Review)
+        uses: actions/github-script@v7
+        env:
+          SHA: ${{ steps.prep.outputs.sha }}
+          OK: ${{ steps.call.outputs.ok }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = process.env.SHA;
+            const ok = (process.env.OK === 'true');
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: ok ? 'success' : 'failure',
+              context: 'Claude Review',
+              description: ok ? 'Claude review posted' : 'Claude review unavailable'
+            });


### PR DESCRIPTION
This PR introduces the Claude automated review workflow that runs on pull_request and pull_request_target. It posts a review comment and sets a commit status "Claude Review" so we can make it a required check.\n\nNotes:\n- Uses secret ANTHROPIC_API_KEY (already configured).\n- Least privilege: contents read, pull-requests write, statuses write.\n- Safe logging: never prints the API key.\n\nAfter merge into develop, I will open develop -> main and then add "Claude Review" to required checks once it appears on a live PR.