### PR TITLE
🚫 Stop Dependabot daily spam - switch to monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+      day: 1
       time: "04:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(deps)"
     versioning-strategy: widen

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --legacy-peer-deps
 
       - name: Run CI checks
         id: checks


### PR DESCRIPTION
## The Problem
Dependabot creates PRs **EVERY SINGLE DAY** that require manual merging. This is exhausting and unnecessary.

## The Solution  
This PR reduces Dependabot updates from daily to monthly:
- ✅ Change schedule from **daily** to **monthly** (first of each month only)
- ✅ Reduce open PR limit from 10 to 2
- ✅ Fix npm install conflicts with `--legacy-peer-deps` flag

## Impact
No more daily Dependabot harassment. You'll only see dependency PRs once a month, and the automation will handle them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update cadence from daily to monthly (runs on the 1st at 04:00) to reduce noise.
  * Limited simultaneous automated dependency PRs to 2 for smoother review flow.
  * Updated automated merge workflow to install with legacy peer dependency handling, reducing CI failures on dependency PRs.
  * No user-facing changes; improves reliability and maintainability of dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->